### PR TITLE
There was a typo in the gem name which caused issues.

### DIFF
--- a/pagerduty-full.gemspec
+++ b/pagerduty-full.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
-  s.name        = 'pagerdut-full'
-  s.version     = '0.0.1'
-  s.date        = '2012-10-01'
+  s.name        = 'pagerduty-full'
+  s.version     = '0.0.2'
+  s.date        = '2013-03-08'
   s.summary     = "PagerDuty API Access"
   s.description = "Access to all of PagerDuty's API"
   s.authors     = ["Cory Watson"]


### PR DESCRIPTION
This commit fixes that and bumps the version number
