### PR TITLE
Update URI to use HTTPS instead of HTTP

### DIFF
--- a/lib/pagerduty/base.rb
+++ b/lib/pagerduty/base.rb
@@ -14,7 +14,7 @@ module PagerDuty
 
     def api_call(path, params)
 
-      uri = URI.parse("http://#{@subdomain}.pagerduty.com/api/v1/#{path}")
+      uri = URI.parse("https://#{@subdomain}.pagerduty.com/api/v1/#{path}")
       http = Net::HTTP.new(uri.host, uri.port)
 
       # This is probably stupid

--- a/pagerduty-full.gemspec
+++ b/pagerduty-full.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
-  s.name        = 'pagerdut-full'
-  s.version     = '0.0.1'
-  s.date        = '2012-10-01'
+  s.name        = 'pagerduty-full'
+  s.version     = '0.0.2'
+  s.date        = '2014-03-31'
   s.summary     = "PagerDuty API Access"
   s.description = "Access to all of PagerDuty's API"
   s.authors     = ["Cory Watson"]


### PR DESCRIPTION
Following an e-mail from PagerDuty, they're going to stop supporting API access over HTTP.
