### PR TITLE
Add missing dep on OpenSSL

### DIFF
--- a/lib/pagerduty/base.rb
+++ b/lib/pagerduty/base.rb
@@ -1,6 +1,7 @@
 require 'json'
 require 'net/http'
 require 'uri'
+require 'openssl'
 
 module PagerDuty
   class Full

--- a/pagerduty-full.gemspec
+++ b/pagerduty-full.gemspec
@@ -8,4 +8,6 @@ Gem::Specification.new do |s|
   s.email       = 'gphat@onemogin.com'
   s.files       = ["lib/pagerduty/full.rb"]
   s.homepage    = 'http://github.com/gphat/pagerduty-full'
+
+  s.add_runtime_dependency 'openssl'
 end


### PR DESCRIPTION
Fixing that error

irb(main):006:0> pd = PagerDuty::Full.new(apikey = "XXXX", subdomain = "CORP")
=> #<PagerDuty::Full:0x007faa1c1afe50 @apikey="XXXX", @subdomain="CORP">
irb(main):007:0> schedule = pd.Schedule.search()
NameError: uninitialized constant PagerDuty::Full::OpenSSL
    from /Users/oaouf/.rbenv/versions/2.0.0-p451/lib/ruby/gems/2.0.0/gems/pagerduty-full-0.1.2/lib/pagerduty/base.rb:20:in `api_call'
    from /Users/oaouf/.rbenv/versions/2.0.0-p451/lib/ruby/gems/2.0.0/gems/pagerduty-full-0.1.2/lib/pagerduty/resource/schedule.rb:20:in`search'
    from (irb):7
    from /Users/oaouf/.rbenv/versions/2.0.0-p451/bin/irb:12:in `<main>'
