### PR TITLE
add proxy capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ require 'pagerduty/full'
 start_date = Date.parse("2012-09-24T00:00Z")
 end_date = Date.parse("2012-10-09T07:01Z")
 
-pd = PagerDuty::Full.new(apikey = YOURKEY, subdomain = YOURDOMAIN)
+pd = PagerDuty::Full.new(apikey = YOURKEY, subdomain = YOURDOMAIN, http_proxy = PROXY_URL)
+
+YOURKEY is required, get one from https://YOURDOMAIN.pagerduty.com/api_keys
+YOURDOMAIN is required, the pagerduty.com subdomain
+PROXY_URL is optional, format http(s)://USER:PASS@HOST:PORT, USER & PASS are optional
 
 # Get list of schedules
 sched = pd.Schedule.search()


### PR DESCRIPTION
This adds proxy'ing capability.
Updated README.
Also, removes one unused Net::HTTP::Get.new line.
## Tested scenarios
1. Bad proxy host or port (running localhost:8080):
   `1.9.3-p547 :003 > pd = PagerDuty::Full.new(apikey = 'MY_KEY', subdomain = 'MY_DOMAIN', http_proxy = "http://localhost:8081")`
   `=> #<PagerDuty::Full:0x007fa5739b79c0 @apikey="MY_KEY", @subdomain="MY_DOMAIN", @http_proxy=["http://localhost:8081"]>`
   `1.9.3-p547 :004 > sched = pd.Schedule.search().length`
   `Errno::ECONNREFUSED: Connection refused - connect(2)`
2. Good proxy host and port:
   `1.9.3-p547 :005 > pd = PagerDuty::Full.new(apikey = 'MY_KEY', subdomain = 'MY_DOMAIN', http_proxy = "http://localhost:8080")`
   `=> #<PagerDuty::Full:0x007fa573960508 @apikey="MY_KEY", @subdomain="MY_DOMAIN", @http_proxy=["http://localhost:8080"]>`
   `1.9.3-p547 :006 > sched = pd.Schedule.search().length`
   `=> 4`
3. No proxy:
   `1.9.3-p547 :007 > pd = PagerDuty::Full.new(apikey = 'MY_KEY', subdomain = 'MY_DOMAIN')`
   `=> #<PagerDuty::Full:0x007fa57483f3a8 @apikey="MY_KEY", @subdomain="MY_DOMAIN", @http_proxy=[]>`
   `1.9.3-p547 :008 > sched = pd.Schedule.search().length`
   `=> 4`
